### PR TITLE
feat: use resize observer to make flamegraph responsive with respect to the width of its parent element

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3553,6 +3553,12 @@
       "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
       "dev": true
     },
+    "@types/resize-observer-browser": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/resize-observer-browser/-/resize-observer-browser-0.1.5.tgz",
+      "integrity": "sha512-8k/67Z95Goa6Lznuykxkfhq9YU3l1Qe6LNZmwde1u7802a3x8v44oq0j91DICclxatTr0rNnhXx7+VTIetSrSQ==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",

--- a/package.json
+++ b/package.json
@@ -33,16 +33,22 @@
     "zone.js": "~0.10.3"
   },
   "devDependencies": {
+    "@angular-devkit/architect": "<0.900 || ^0.900.0-0 || ^9.0.0-0",
     "@angular-devkit/build-angular": "~0.1100.2",
     "@angular/cli": "~11.0.2",
     "@angular/compiler-cli": "~11.0.2",
     "@angular/language-service": "~11.0.2",
     "@nguniversal/builders": "^11.0.0",
     "@types/express": "^4.17.0",
-    "@types/node": "^12.11.1",
     "@types/jasmine": "~3.6.0",
     "@types/jasminewd2": "~2.0.3",
+    "@types/node": "^12.11.1",
+    "@types/resize-observer-browser": "^0.1.5",
     "codelyzer": "^6.0.0",
+    "firebase-tools": "^8.16.2",
+    "fuzzy": "^0.1.3",
+    "inquirer": "^6.2.2",
+    "inquirer-autocomplete-prompt": "^1.0.1",
     "jasmine-core": "~3.6.0",
     "jasmine-spec-reporter": "~5.0.0",
     "karma": "~5.1.1",
@@ -54,11 +60,6 @@
     "protractor": "~7.0.0",
     "ts-node": "~8.3.0",
     "tslint": "~6.1.0",
-    "typescript": "~4.0.5",
-    "@angular-devkit/architect": "<0.900 || ^0.900.0-0 || ^9.0.0-0",
-    "firebase-tools": "^8.16.2",
-    "fuzzy": "^0.1.3",
-    "inquirer": "^6.2.2",
-    "inquirer-autocomplete-prompt": "^1.0.1"
+    "typescript": "~4.0.5"
   }
 }

--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.html
@@ -1,5 +1,5 @@
 <svg:rect
-  (dblclick)="select()"
+  (dblclick)="zoom.emit(entry)"
   stroke="white"
   stroke-width="1px"
   pointer-events="all"

--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
@@ -13,8 +13,4 @@ export class FlamegraphNodeComponent {
   @Input() height: number;
   @Input() width: number;
   @Output() zoom = new EventEmitter();
-
-  select() {
-    this.zoom.emit(this.entry);
-  }
 }

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
@@ -5,7 +5,7 @@
        (click)="frameClick.emit(entry.original)"
        (mouseover)="frameMouseEnter.emit(entry.original)"
        (mouseleave)="frameMouseLeave.emit(entry.original)"
-       (zoom)="select($event)"
+       (zoom)="zoom.emit($event)"
        [entry]="entry"
        [height]="levelHeight"
        [width]="getWidth(entry)"

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
@@ -15,6 +15,7 @@ export class FlamegraphComponent {
   @Output() frameClick = new EventEmitter<RawData>();
   @Output() frameMouseEnter = new EventEmitter<RawData>();
   @Output() frameMouseLeave = new EventEmitter<RawData>();
+  @Output() zoom = new EventEmitter<Data>();
 
   @Input() width: number;
   @Input() levelHeight: number;
@@ -40,100 +41,4 @@ export class FlamegraphComponent {
   getWidth(entry: Data) {
     return entry.widthRatio * this.width || 0;
   }
-
-  select(entry: Data) {
-    if (entry.navigable) {
-      restore(entry);
-    }
-    transformData(entry, this.layout);
-  }
-
-  clearSelection() {
-    this.selectedData = [];
-  }
 }
-
-const collapse = (e: Data) => {
-  e.widthRatio = 0;
-  e.children.forEach(collapse);
-};
-
-const collapseOthers = (entry: Data) => {
-  entry.siblings.forEach(e => {
-    if (e === entry) {
-      return;
-    }
-    collapse(e);
-  });
-  let current = entry;
-  while (current.parent) {
-    current = current.parent;
-    if (current.widthRatio === 0) {
-      continue;
-    }
-    collapseOthers(current);
-  }
-};
-
-const hide = (leftRatio: number, node: Data) => {
-  node.widthRatio = 0;
-  node.leftRatio = leftRatio;
-  node.children.forEach(n => hide(leftRatio, n));
-};
-
-const hideSiblings = (node: Data) => {
-  const idx = node.siblings.indexOf(node);
-  for (let i = 0; i < idx; i++) {
-    node.siblings[i].widthRatio = 0;
-    node.siblings[i].leftRatio = 0;
-    node.siblings[i].children.forEach(hide.bind(null, 0));
-  }
-  for (let i = idx + 1; i < node.siblings.length; i++) {
-    node.siblings[i].widthRatio = 0;
-    node.siblings[i].leftRatio = 1;
-    node.siblings[i].children.forEach(hide.bind(null, 1));
-  }
-};
-
-const transformData = (focused: Data, layout: SiblingLayout) => {
-  let current: Data | null = focused;
-  while (current) {
-    current.widthRatio = 1;
-    current.leftRatio = 0;
-    hideSiblings(current);
-    current = current.parent;
-    if (current) {
-      current.navigable = true;
-    }
-  }
-  adjustChildren(focused.children, layout);
-};
-
-const adjustChildren = (
-  data: Data[],
-  layout: SiblingLayout,
-  leftRatio = 0,
-  parentRatio = 1
-) => {
-  let totalValue = 0;
-  data.forEach(entry => {
-    totalValue += entry.value;
-  });
-  data.forEach(entry => {
-    let widthRatio = (entry.value / totalValue) * parentRatio;
-    if (layout === 'equal') {
-      widthRatio = parentRatio / data.length;
-    }
-    entry.widthRatio = widthRatio;
-    entry.leftRatio = leftRatio;
-    adjustChildren(entry.children, layout, leftRatio, widthRatio);
-    leftRatio += widthRatio;
-  });
-};
-
-const restore = (entry: Data) => {
-  entry.navigable = false;
-  entry.leftRatio = entry.originalLeftRatio;
-  entry.widthRatio = entry.originalWidthRatio;
-  entry.children.forEach(restore);
-};

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
@@ -1,7 +1,9 @@
 <ngx-flamegraph-graph
+  *ngIf="width !== null"
   (frameClick)="frameClick.emit($event)"
   (frameMouseEnter)="frameMouseEnter.emit($event)"
   (frameMouseLeave)="frameMouseLeave.emit($event)"
+  (zoom)="onZoom($event)"
   [layout]="siblingLayout"
   [data]="entries"
   [depth]="depth"

--- a/projects/ngx-flamegraph/src/lib/utils.ts
+++ b/projects/ngx-flamegraph/src/lib/utils.ts
@@ -106,3 +106,102 @@ export const transformRawData = (
   });
   return result;
 };
+
+export const findDepth = (data: RawData[] | undefined) => {
+  if (!data) {
+    return 0;
+  }
+  if (!data.length) {
+    return 0;
+  }
+  let result = 0;
+  for (const row of data) {
+    result = Math.max(1 + findDepth(row.children), result);
+  }
+  return result;
+};
+
+const collapse = (e: Data) => {
+  e.widthRatio = 0;
+  e.children.forEach(collapse);
+};
+
+const collapseOthers = (entry: Data) => {
+  entry.siblings.forEach(e => {
+    if (e === entry) {
+      return;
+    }
+    collapse(e);
+  });
+  let current = entry;
+  while (current.parent) {
+    current = current.parent;
+    if (current.widthRatio === 0) {
+      continue;
+    }
+    collapseOthers(current);
+  }
+};
+
+const hide = (leftRatio: number, node: Data) => {
+  node.widthRatio = 0;
+  node.leftRatio = leftRatio;
+  node.children.forEach(n => hide(leftRatio, n));
+};
+
+const hideSiblings = (node: Data) => {
+  const idx = node.siblings.indexOf(node);
+  for (let i = 0; i < idx; i++) {
+    node.siblings[i].widthRatio = 0;
+    node.siblings[i].leftRatio = 0;
+    node.siblings[i].children.forEach(hide.bind(null, 0));
+  }
+  for (let i = idx + 1; i < node.siblings.length; i++) {
+    node.siblings[i].widthRatio = 0;
+    node.siblings[i].leftRatio = 1;
+    node.siblings[i].children.forEach(hide.bind(null, 1));
+  }
+};
+
+export const transformData = (focused: Data, layout: SiblingLayout) => {
+  let current: Data | null = focused;
+  while (current) {
+    current.widthRatio = 1;
+    current.leftRatio = 0;
+    hideSiblings(current);
+    current = current.parent;
+    if (current) {
+      current.navigable = true;
+    }
+  }
+  adjustChildren(focused.children, layout);
+};
+
+const adjustChildren = (
+  data: Data[],
+  layout: SiblingLayout,
+  leftRatio = 0,
+  parentRatio = 1
+) => {
+  let totalValue = 0;
+  data.forEach(entry => {
+    totalValue += entry.value;
+  });
+  data.forEach(entry => {
+    let widthRatio = (entry.value / totalValue) * parentRatio;
+    if (layout === 'equal') {
+      widthRatio = parentRatio / data.length;
+    }
+    entry.widthRatio = widthRatio;
+    entry.leftRatio = leftRatio;
+    adjustChildren(entry.children, layout, leftRatio, widthRatio);
+    leftRatio += widthRatio;
+  });
+};
+
+export const restore = (entry: Data) => {
+  entry.navigable = false;
+  entry.leftRatio = entry.originalLeftRatio;
+  entry.widthRatio = entry.originalWidthRatio;
+  entry.children.forEach(restore);
+};

--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,9 +1,15 @@
-.wrapper {
+.wrapper-fixed-width {
   width: 900px;
+  margin: auto;
+
+}
+
+.wrapper-responsive {
+  width: 70%;
   margin: auto;
 }
 
-h2 {
+h2, h3 {
   text-align: center;
   user-select: none;
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,4 +1,11 @@
 <h2>Angular Flame Graph</h2>
-<div class="wrapper">
-  <ngx-flamegraph  [config]="config" [width]="900"></ngx-flamegraph>
+
+<h3> Fixed Width</h3>
+<div class="wrapper-fixed-width">
+  <ngx-flamegraph [config]="config"></ngx-flamegraph>
+</div>
+
+<h3> Responsive </h3>
+<div class="wrapper-responsive">
+  <ngx-flamegraph [config]="config"></ngx-flamegraph>
 </div>


### PR DESCRIPTION
Wanted there to be a way for the flamegraph to be responsive out of the box. This PR does the following:

- Uses [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) to make flamegraph responsive with respect to the width of its parent element, **only if the `width` input is not provided to `ngx-flamegraph`**.
- Adds responsive example to demo app.

Unrelated:
- Pulls util functions out of `flamegraph.component.ts` and places them into `utils.ts`.

