### PR TITLE
perf: handle mouseover and mouseleave events outside angular zone 

### DIFF
--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, Output, ViewEncapsulation} from '@angular/core';
+import { Component, EventEmitter, Input, Output, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
 import {Data} from '../utils';
 
 @Component({
@@ -6,7 +6,8 @@ import {Data} from '../utils';
   selector: '[flamegraph-node]',
   templateUrl: './flamegraph-node.component.html',
   styleUrls: ['./flamegraph-node.component.css'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FlamegraphNodeComponent {
   @Input() entry: Data;

--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
@@ -1,17 +1,61 @@
-import { Component, EventEmitter, Input, Output, ViewEncapsulation, ChangeDetectionStrategy } from '@angular/core';
-import {Data} from '../utils';
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  ViewEncapsulation,
+  ChangeDetectionStrategy,
+  Renderer2,
+  ElementRef,
+  NgZone,
+  OnDestroy,
+} from "@angular/core";
+import { Data } from "../utils";
 
 @Component({
   // tslint:disable-next-line:component-selector
-  selector: '[flamegraph-node]',
-  templateUrl: './flamegraph-node.component.html',
-  styleUrls: ['./flamegraph-node.component.css'],
+  selector: "[flamegraph-node]",
+  templateUrl: "./flamegraph-node.component.html",
+  styleUrls: ["./flamegraph-node.component.css"],
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class FlamegraphNodeComponent {
+export class FlamegraphNodeComponent implements OnDestroy {
   @Input() entry: Data;
   @Input() height: number;
   @Input() width: number;
   @Output() zoom = new EventEmitter();
+
+  @Output() mouseOverZoneless = new EventEmitter();
+  @Output() mouseLeaveZoneless = new EventEmitter();
+
+  private mouseOverTeardownFn: Function;
+  private mouseLeaveTeardownFn: Function;
+
+  constructor(
+    private _ngZone: NgZone,
+    private _element: ElementRef,
+    private _renderer: Renderer2
+  ) {}
+
+  ngOnInit(): void {
+    this._ngZone.runOutsideAngular(() => {
+      this.mouseOverTeardownFn = this._renderer.listen(
+        this._element.nativeElement,
+        "mouseover",
+        (event: MouseEvent) => this.mouseOverZoneless.emit(event)
+      );
+
+      this.mouseLeaveTeardownFn = this._renderer.listen(
+        this._element.nativeElement,
+        "mouseleave",
+        (event: MouseEvent) => this.mouseLeaveZoneless.emit(event)
+      );
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.mouseOverTeardownFn();
+    this.mouseLeaveTeardownFn();
+  }
 }

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
@@ -3,8 +3,8 @@
     <g flamegraph-node
        *ngFor="let entry of entries; index as i"
        (click)="frameClick.emit(entry.original)"
-       (mouseover)="frameMouseEnter.emit(entry.original)"
-       (mouseleave)="frameMouseLeave.emit(entry.original)"
+       (mouseOverZoneless)="frameMouseEnter.emit(entry.original)"
+       (mouseLeaveZoneless)="frameMouseLeave.emit(entry.original)"
        (zoom)="zoom.emit($event)"
        [entry]="entry"
        [height]="levelHeight"

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
@@ -1,12 +1,13 @@
 import { Data, RawData, SiblingLayout } from '../utils';
-import { Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
+import { ChangeDetectionStrategy, Component, EventEmitter, Input, Output, ViewEncapsulation } from '@angular/core';
 
 @Component({
   // tslint:disable-next-line:component-selector
   selector: 'ngx-flamegraph-graph',
   templateUrl: './flamegraph.component.html',
   styleUrls: ['./flamegraph.component.css'],
-  encapsulation: ViewEncapsulation.None
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class FlamegraphComponent {
   selectedData: Data[] = [];

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
@@ -1,8 +1,8 @@
 <ngx-flamegraph-graph
   *ngIf="width !== null"
   (frameClick)="frameClick.emit($event)"
-  (frameMouseEnter)="frameMouseEnter.emit($event)"
-  (frameMouseLeave)="frameMouseLeave.emit($event)"
+  (frameMouseEnter)="onFrameMouseEnter($event)"
+  (frameMouseLeave)="onFrameMouseLeave($event)"
   (zoom)="onZoom($event)"
   [layout]="siblingLayout"
   [data]="entries"

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.ts
@@ -53,7 +53,7 @@ export class NgxFlamegraphComponent implements OnInit, OnDestroy {
         this._ngZone.run(() => this._onParentResize())
       );
       this._resizeObserver.observe(parent);
-      
+
     }
   }
 
@@ -88,5 +88,21 @@ export class NgxFlamegraphComponent implements OnInit, OnDestroy {
       restore(entry);
     }
     transformData(entry, this.siblingLayout);
+  }
+
+  onFrameMouseEnter(data: RawData): void {
+    if (this.frameMouseEnter.observers.length === 0) {
+      return;
+    }
+
+    this._ngZone.run(() => this.frameMouseEnter.emit(data));
+  }
+
+  onFrameMouseLeave(data: RawData): void {
+    if (this.frameMouseLeave.observers.length === 0) {
+      return;
+    }
+
+    this._ngZone.run(() => this.frameMouseLeave.emit(data));
   }
 }


### PR DESCRIPTION
- Added OnPush on `flamegraph-node` and `flamegraph` components.
- Listen to mouseover and mouseleave outside angular zone. 
- frameMouseEnter / frameMouseLeave will emit only when they have active observers
