### PR TITLE
perf: optimize flamegraph animations

### DIFF
--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.css
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.css
@@ -1,20 +1,3 @@
-.ngx-fg-label {
-  text-overflow: ellipsis;
-  width: 100%;
-  height: 100%;
-  overflow: hidden;
-  color: white;
-  padding: 5px;
-  font-family: sans-serif;
-  font-size: 80%;
-  cursor: pointer;
-  user-select: none;
-}
-
 .ngx-fg-navigable {
-  opacity: 0.5;
-}
-
-.ngx-fg-rect {
-  transition: width 0.2s ease-out, transform 0.2s ease-out;
+    opacity: 0.5;
 }

--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.html
@@ -1,20 +1,13 @@
 <svg:rect
-  (dblclick)="zoom.emit(entry)"
+  (dblclick)="zoom.emit()"
   stroke="white"
   stroke-width="1px"
   pointer-events="all"
+  width="100%"
   rx="1"
   ry="1"
   class="ngx-fg-rect"
-  [class.ngx-fg-navigable]="entry.navigable"
-  [attr.width]="width"
+  [class.ngx-fg-navigable]="navigable"
   [attr.height]="height"
-  [attr.fill]="entry.color">
+  [attr.fill]="color">
 </svg:rect>
-<svg:foreignObject
-  [attr.width]="width"
-  [attr.height]="height">
-  <xhtml:div class="ngx-fg-label" [class.ngx-fg-navigable]="entry.navigable">
-    {{entry.label}}
-  </xhtml:div>
-</svg:foreignObject>

--- a/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph-node/flamegraph-node.component.ts
@@ -10,7 +10,6 @@ import {
   NgZone,
   OnDestroy,
 } from "@angular/core";
-import { Data } from "../utils";
 
 @Component({
   // tslint:disable-next-line:component-selector
@@ -21,10 +20,11 @@ import { Data } from "../utils";
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class FlamegraphNodeComponent implements OnDestroy {
-  @Input() entry: Data;
   @Input() height: number;
-  @Input() width: number;
-  @Output() zoom = new EventEmitter();
+  @Input() navigable: boolean = false;
+  @Input() color: string;
+
+  @Output() zoom = new EventEmitter<void>();
 
   @Output() mouseOverZoneless = new EventEmitter();
   @Output() mouseLeaveZoneless = new EventEmitter();
@@ -34,7 +34,7 @@ export class FlamegraphNodeComponent implements OnDestroy {
 
   constructor(
     private _ngZone: NgZone,
-    private _element: ElementRef,
+    private _element: ElementRef<HTMLElement>,
     private _renderer: Renderer2
   ) {}
 

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.css
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.css
@@ -3,19 +3,33 @@
 }
 
 ngx-flamegraph-graph {
-  position: relative;
+  position: absolute;
   display: block;
+  overflow: hidden;
 }
 
-.ngx-fg-chart-wrapper {
-  position: relative;
+.svg-wrapper {
+  width: 100%;
+  transform-origin: left;
 }
 
-.ngx-fg-grayscale {
-  filter: grayscale(1);
-  opacity: 0.2;
+.svg-wrapper {
+  transition: transform 0.333s ease-in-out, opacity 0.333s ease-in-out;
 }
 
-.ngx-fg-svg-g {
-  transition: width 0.2s ease-out, transform 0.2s ease-out;
+.bar-text {
+  position: absolute;
+  z-index: 1;
+  overflow: hidden;
+  pointer-events: none;
+  user-select: none;
+  color: white;
+  padding: 5px;
+  font-family: sans-serif;
+  font-size: 80%;
+}
+
+.hide-bar {
+  opacity: 0;
+  pointer-events: none;
 }

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
@@ -1,16 +1,51 @@
+<!-- 
+  This component relies on css transform translate and scaleX in order to animate the positioning and expansion of flamegraph bars.
+
+  Notably there were two design decisions made to optimize this component:
+
+    1. No animations are performed on svg elements. Animating vector graphics requires the browser to rasterize each indiviudal frame (even if we're simply animating on transform translate). Instead svg elements are wrapped in divs and their parent divs are animated with transform translate, which skips rasterization and jumps straight to compositing.
+    2. Expansion animations rely on animating transform scaleX instead of width. Animating width would cause the browser to trigger layout recalculation on each frame, whereas animating transform scaleX relies on the compositor.
+-->
+
 <div class="ngx-fg-chart-wrapper" [class.ngx-fg-grayscale]="selectedData && selectedData.length">
-  <svg class="ngx-fg-svg" [attr.width]="width" [attr.height]="height" [attr.viewBox]="'0 0 ' + width + ' ' + height ">
-    <g flamegraph-node
-       *ngFor="let entry of entries; index as i"
-       (click)="frameClick.emit(entry.original)"
-       (mouseOverZoneless)="frameMouseEnter.emit(entry.original)"
-       (mouseLeaveZoneless)="frameMouseLeave.emit(entry.original)"
-       (zoom)="zoom.emit($event)"
-       [entry]="entry"
-       [height]="levelHeight"
-       [width]="getWidth(entry)"
-       class="ngx-fg-svg-g"
-       [style.transform]="'translate(' + getLeft(entry) + 'px,' + getTop(entry) + 'px)'">
-    </g>
-  </svg>
+  <!--
+    This first wrapper will let us perform a translate transform to position the bar without triggering rasterization.
+  -->
+  <div
+    [class.hide-bar]="!(minimumBarSize === undefined || getWidth(entry) > minimumBarSize)"
+    class="svg-wrapper"
+    [style.position]="'absolute'"
+    [style.transform] = "'translate(' + getLeft(entry) + 'px,' + getTop(entry) + 'px)'"
+    [style.height.px]="levelHeight"
+    *ngFor="let entry of entries; index as i"
+  >
+    <div class="bar-text" [style.width.px]="getWidth(entry)">
+      {{ entry.label }}
+    </div>
+
+    <!-- 
+      This second wrapper will let us perform a scaleX transform to shrink the bar without triggering rasterization.
+
+      We need to separate this from the positioning wrappe because otherwise the label text would scale as well.
+    -->
+    <div
+    class="svg-wrapper"
+    [style.transform]="'scaleX(' + getWidth(entry) / width + ')'"
+    [style.height.px]="levelHeight"
+    >
+      <svg class="ngx-fg-svg" width="100%" height="100%">
+        <g flamegraph-node
+          (click)="frameClick.emit(entry.original)"
+          (mouseOverZoneless)="frameMouseEnter.emit(entry.original)"
+          (mouseLeaveZoneless)="frameMouseLeave.emit(entry.original)"
+          (zoom)="zoom.emit(entry)"
+          [height]="levelHeight"
+          [navigable]="entry.navigable"
+          [color]="entry.color"
+          class="ngx-fg-svg-g"
+          >
+        </g>
+      </svg>
+    </div>
+  </div>
 </div>

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
@@ -22,6 +22,8 @@ export class FlamegraphComponent {
   @Input() levelHeight: number;
   @Input() layout: SiblingLayout;
   @Input() depth: number;
+  @Input() minimumBarSize: number|undefined;
+
 
   @Input() set data(data: Data[]) {
     this.entries = data;

--- a/projects/ngx-flamegraph/src/lib/ngx-flamechart.component.css
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamechart.component.css
@@ -1,4 +1,3 @@
 ngx-flamegraph {
-  position: relative;
   display: block;
 }

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
@@ -8,5 +8,9 @@
   [data]="entries"
   [depth]="depth"
   [levelHeight]="levelHeight"
-  [width]="width">
+  [width]="width"
+  [style.height.px]="depth * levelHeight"
+  [style.width.px]="width"
+  [minimumBarSize]="minimumBarSize"
+  >
 </ngx-flamegraph-graph>

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.ts
@@ -1,11 +1,12 @@
 /// <reference types="resize-observer-browser" />
-import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, ViewEncapsulation, OnInit, OnDestroy, ChangeDetectorRef, ElementRef, NgZone } from '@angular/core';
+import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy, ViewEncapsulation, OnInit, OnDestroy, ChangeDetectorRef, ElementRef, NgZone, HostBinding } from '@angular/core';
 import { Data, RawData, transformRawData, maxValue, SiblingLayout, FlamegraphColor, Color, restore, findDepth, transformData } from './utils';
 import { defaultColors } from './constants';
 
 export interface FlameGraphConfig {
   color?: FlamegraphColor;
   data: RawData[];
+  minimumBarSize?: number // smallest that a bar can be in pixels and still be rendered
 }
 
 const isResizeObserverAvailable = typeof ResizeObserver !== 'undefined';
@@ -34,13 +35,20 @@ export class NgxFlamegraphComponent implements OnInit, OnDestroy {
   @Input() width: number | null = null;
   @Input() levelHeight = 25;
 
+  minimumBarSize: number;
+
   @Input() set config(config: FlameGraphConfig) {
     this._data = config.data;
     this._colors = config.color ?? defaultColors;
+    this.minimumBarSize = config.minimumBarSize ?? 2;
     this._refresh();
   }
 
   private _resizeObserver: ResizeObserver;
+
+  @HostBinding('attr.style') get hostStyles() {
+    return `height: ${this.depth * this.levelHeight}px `;
+  }
 
   constructor(private _el: ElementRef, public cdr: ChangeDetectorRef, private _ngZone: NgZone) { }
 


### PR DESCRIPTION
Notably there were two design decisions made to optimize the flamegraph component:

1. No animations are performed on svg elements. Animating vector graphics requires the browser to rasterize each indiviudal frame (even if we're simply animating on transform translate). Instead svg elements are wrapped in divs and these divs are animated with transform translate. This skips rasterization and jumps straight to compositing.
2. Expansion/compression animations rely on animating transform scaleX instead of width. Animating width would cause the browser to trigger layout, paint and composite calculations on each frame, whereas animating transform scaleX relies only on the compositor.