### PR TITLE
feat(flamegraph): add stylization CSS vars; implement a tooltip

### DIFF
--- a/projects/ngx-flamegraph/README.md
+++ b/projects/ngx-flamegraph/README.md
@@ -41,13 +41,14 @@ interface Data {
   template: `
     <ngx-flamegraph
        [config]="{ data, color }"
-       [frameClick]="handleClick($event)"
-       [frameMouseEnter]="handleMouseEnter($event)"
-       [frameMouseLeave]="handleMouseLeave($event)"
+       (frameClick)="handleClick($event)"
+       (frameMouseEnter)="handleMouseEnter($event)"
+       (frameMouseLeave)="handleMouseLeave($event)"
        siblingLayout="relative"
        [width]="width"
-       [levelHeight]="30">
-    </ngx-flamegraph>
+       [levelHeight]="30"
+       [tooltipEnabled]="true"
+    ></ngx-flamegraph>
   `
 })
 export class AppComponent implements OnInit {
@@ -57,7 +58,7 @@ export class AppComponent implements OnInit {
   color = {
     hue: [50, 0],
     saturation: [80, 80],
-    lightness: [55, 60]
+    lightness: [55, 60],
   };
   data = [
     {
@@ -66,8 +67,8 @@ export class AppComponent implements OnInit {
       children: [
         { label: 'foo', value: 8, children: [] },
         { label: 'bar', value: 8, color: '#ff0000', children: [] },
-      ]
-    }
+      ],
+    },
   ];
 
   handleClick(entry: Data) {
@@ -89,7 +90,30 @@ export class AppComponent implements OnInit {
 - `data` - property of type `RawData[]`. `RawData` is the same interface as `Data` in the example above.
 - `siblingLayout` - `equal` or `relative`. Equal will set all the siblings with the same width, compared to `relative`, which will look at their values relative to the sum of the values of all the siblings.
 - `width` - sets the width of the chart.
-- `levelHeight` - sets the height per level of the chart.
+- `levelHeight` - sets the height per level of the chart. Default `25`.
+- `tooltipEnabled` - shows a tooltip for the narrow bars that can't display the whole label. Default: `false`.
+
+## Stylization
+
+The component exposes several CSS variables for custom stylization:
+
+```css
+ngx-flamegraph {
+  /* Font family – affects both the flamegraph bars and the tooltips */
+  --ngx-fg-font-family: sans-serif;
+
+  /* Bar */
+  --ngx-fg-bar-font-size: 0.8rem;
+  --ngx-fg-bar-text-color: white;
+  --ngx-fg-bar-padding-inline: 0.375rem;
+
+  /* Tooltip */
+  --ngx-fg-tooltip-font-size: 0.75rem;
+  --ngx-fg-tooltip-padding: 0.375rem 0.5rem;
+  --ngx-fg-tooltip-text-color: white;
+  --ngx-fg-tooltip-background: rgba(0, 0, 0, 0.8);
+}
+```
 
 ## Related work
 
@@ -104,4 +128,3 @@ export class AppComponent implements OnInit {
 ## License
 
 MIT
-

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.css
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.css
@@ -12,12 +12,16 @@ ngx-flamegraph-graph {
   overflow: hidden;
   width: 100%;
   user-select: none;
-  color: white;
-  font-family: sans-serif;
-  font-size: 80%;
+  color: var(--ngx-fg-bar-text-color, white);
+  font-family: var(--ngx-fg-font-family, sans-serif);
+  font-size: var(--ngx-fg-bar-font-size, 0.8rem);
   box-sizing: border-box;
   cursor: default;
   will-change: transform;
+}
+
+.ngx-fg-bar:hover {
+  filter: brightness(110%);
 }
 
 .ngx-fg-bar::before {
@@ -43,7 +47,7 @@ ngx-flamegraph-graph {
   height: inherit;
   width: 100%;
   overflow: hidden;
-  padding: 4px 5px;
+  padding-inline: var(--ngx-fg-bar-padding-inline, 0.375rem);
   box-sizing: border-box;
 }
 
@@ -57,4 +61,19 @@ ngx-flamegraph-graph {
 
 .ngx-fg-navigable {
   opacity: 0.5;
+}
+
+.ngx-fg-tooltip {
+  position: fixed;
+  top: 15px;
+  left: 10px;
+  font-family: var(--ngx-fg-font-family, sans-serif);
+  font-size: var(--ngx-fg-tooltip-font-size, 0.75rem);
+  padding: var(--ngx-fg-tooltip-padding, 0.375rem 0.5rem);
+  color: var(--ngx-fg-tooltip-text-color, white);
+  background: var(--ngx-fg-tooltip-background, rgba(0, 0, 0, 0.8));
+  box-shadow: 0 2px 3px rgba(0, 0, 0, 0.2);
+  border-radius: 0.2rem;
+  pointer-events: none;
+  z-index: 1;
 }

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
@@ -12,6 +12,7 @@
       [class.ngx-fg-hide-bar]="!(minimumBarSize === undefined || getWidth(entry) > minimumBarSize)"
       [class.ngx-fg-navigable]="entry.navigable"
       [style.height.px]="levelHeight"
+      [style.line-height.px]="levelHeight"
       [style.transform]="'translate(' + getLeft(entry) + 'px,' + getTop(entry) + 'px)'"
       [attr.data-idx]="i"
       [attr.data-label]="entry.label"

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.html
@@ -12,5 +12,6 @@
   [style.height.px]="depth * levelHeight + depth"
   [style.width.px]="width"
   [minimumBarSize]="minimumBarSize"
+  [tooltipEnabled]="tooltipEnabled"
 >
 </ngx-flamegraph-graph>

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.component.ts
@@ -35,6 +35,7 @@ export interface FlameGraphConfig {
 const isResizeObserverAvailable = typeof ResizeObserver !== 'undefined';
 
 const RESIZE_DEBOUNCE = 125;
+const DEFAULT_LEVEL_HEIGHT = 25;
 
 @Component({
   selector: 'ngx-flamegraph',
@@ -57,12 +58,31 @@ export class NgxFlamegraphComponent implements OnInit, OnDestroy {
   @Output() frameMouseEnter = new EventEmitter<RawData>();
   @Output() frameMouseLeave = new EventEmitter<RawData>();
 
+  /**
+   * `equal` or `relative`. Equal will set all the siblings with the same width, compared to `relative`, which will look at their values relative to the sum of the values of all the siblings.
+   */
   @Input() siblingLayout: SiblingLayout = 'relative';
+
+  /**
+   * Sets the width of the chart.
+   */
   @Input() width: number | null = null;
-  @Input() levelHeight = 25;
+
+  /**
+   * Sets the height per level of the chart. Default `25`.
+   */
+  @Input() levelHeight = DEFAULT_LEVEL_HEIGHT;
+
+  /**
+   * Shows a tooltip for the narrow bars that can't display the whole label. Default: `false`.
+   */
+  @Input() tooltipEnabled: boolean = false;
 
   minimumBarSize: number;
 
+  /**
+   * Flamegraph configuration.
+   */
   @Input() set config(config: FlameGraphConfig) {
     this._data = config.data;
     this._colors = config.color ?? defaultColors;

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,11 +1,11 @@
 <h2>Angular Flame Graph</h2>
 
-<h3> Fixed Width</h3>
+<h3>Fixed Width</h3>
 <div class="wrapper-fixed-width">
   <ngx-flamegraph [config]="config" [width]="900"></ngx-flamegraph>
 </div>
 
-<h3> Responsive </h3>
+<h3>Responsive (with tooltips)</h3>
 <div class="wrapper-responsive">
-  <ngx-flamegraph [config]="config"></ngx-flamegraph>
+  <ngx-flamegraph [config]="config" [tooltipEnabled]="true"></ngx-flamegraph>
 </div>


### PR DESCRIPTION
- Implement a tooltip that appears for narrow bars where the text is possibly truncated.
- Make some of the flamegraph styles customizable via CSS vars.
- Highlight bars on hover.
- Some minor UI tweaks.