### PR TITLE
feat(flamegraph): expose config interfaces

### DIFF
--- a/projects/ngx-flamegraph/src/public-api.ts
+++ b/projects/ngx-flamegraph/src/public-api.ts
@@ -4,3 +4,4 @@
 
 export * from './lib/ngx-flamegraph.component';
 export * from './lib/ngx-flamegraph.module';
+export { FlamegraphColor, RawData } from './lib/utils';


### PR DESCRIPTION
Expose `FlamegraphColor` and `RawData` to the public API since they are part of the main exported config.