### PR TITLE
fix(flamegraph): tooltip positioning and activation

### DIFF
--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.css
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.css
@@ -20,22 +20,21 @@ ngx-flamegraph-graph {
   will-change: transform;
 }
 
-.ngx-fg-bar:hover {
-  filter: brightness(110%);
-}
-
-.ngx-fg-bar::before {
-  content: '';
+.ngx-fg-bar-fill {
   position: absolute;
-  background: var(--bg);
   top: 0;
   left: 0;
   height: inherit;
   width: inherit;
   transition: transform 0.333s ease-in-out;
   transform-origin: left;
+  /* We use a var, so `ng-fg-hide-bar` can easily override the style without !important. */
   transform: scaleX(var(--scale-x));
   will-change: transform;
+}
+
+.ngx-fg-bar-fill:hover {
+  filter: brightness(110%);
 }
 
 .ngx-fg-bar::after {
@@ -49,9 +48,10 @@ ngx-flamegraph-graph {
   overflow: hidden;
   padding-inline: var(--ngx-fg-bar-padding-inline, 0.375rem);
   box-sizing: border-box;
+  pointer-events: none;
 }
 
-.ngx-fg-bar.ngx-fg-hide-bar::before {
+.ngx-fg-bar.ngx-fg-hide-bar > .ngx-fg-bar-fill {
   transform: scaleX(0);
 }
 
@@ -65,8 +65,8 @@ ngx-flamegraph-graph {
 
 .ngx-fg-tooltip {
   position: fixed;
-  top: 15px;
-  left: 10px;
+  top: 0;
+  left: 0;
   font-family: var(--ngx-fg-font-family, sans-serif);
   font-size: var(--ngx-fg-tooltip-font-size, 0.75rem);
   padding: var(--ngx-fg-tooltip-padding, 0.375rem 0.5rem);

--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.html
@@ -14,16 +14,15 @@
       [style.height.px]="levelHeight"
       [style.line-height.px]="levelHeight"
       [style.transform]="'translate(' + getLeft(entry) + 'px,' + getTop(entry) + 'px)'"
-      [attr.data-idx]="i"
       [attr.data-label]="entry.label"
-      [style]="
-        '--scale-x: ' +
-        getScaleXWidth(entry) +
-        '; --bg: ' +
-        entry.color +
-        '; --clip-path: ' +
-        getClipPathWidth(entry)
-      "
-    ></div>
+      [style]="'--clip-path: ' + getClipPathWidth(entry)"
+    >
+      <div
+        class="ngx-fg-bar-fill"
+        [style]="'--scale-x: ' + getScaleXWidth(entry)"
+        [style.background-color]="entry.color"
+        [attr.data-idx]="i"
+      ></div>
+    </div>
   }
 </div>

--- a/projects/ngx-flamegraph/src/lib/ngx-flamegraph.module.ts
+++ b/projects/ngx-flamegraph/src/lib/ngx-flamegraph.module.ts
@@ -3,10 +3,12 @@ import { CommonModule } from '@angular/common';
 
 import { NgxFlamegraphComponent } from './ngx-flamegraph.component';
 import { FlamegraphComponent } from './flamegraph/flamegraph.component';
+import { provideWindow } from './window.provider';
 
 @NgModule({
   declarations: [NgxFlamegraphComponent, FlamegraphComponent],
   imports: [CommonModule],
   exports: [NgxFlamegraphComponent],
+  providers: [provideWindow()],
 })
 export class NgxFlamegraphModule {}

--- a/projects/ngx-flamegraph/src/lib/window.provider.ts
+++ b/projects/ngx-flamegraph/src/lib/window.provider.ts
@@ -1,0 +1,12 @@
+import { isPlatformBrowser } from '@angular/common';
+import { InjectionToken, PLATFORM_ID, Provider, inject } from '@angular/core';
+
+export const WINDOW = new InjectionToken<Window>('WINDOW');
+
+export const provideWindow = (): Provider => ({
+  provide: WINDOW,
+  useFactory: () => {
+    const platformId = inject(PLATFORM_ID);
+    return isPlatformBrowser(platformId) ? window : {};
+  },
+});


### PR DESCRIPTION
- Improve the tooltip positioning when the tooltip container goes out of bounds (i.e. at the edge of the viewport)
- Do not show a tooltip for hidden entries. This change led to switching from `::before` pseudo-element to a real `div` element since it can be targeted by JS. It also handles the faulty hover effect. Other than that, the layout acts the same as before.
- Handle a couple of `NaN` and negative values