### PR TITLE
use textContent instead of innerHTML

### DIFF
--- a/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
+++ b/projects/ngx-flamegraph/src/lib/flamegraph/flamegraph.component.ts
@@ -194,7 +194,7 @@ export class FlamegraphComponent implements OnInit, OnDestroy {
     if (!this._tooltip) {
       const element = this._renderer.createElement('div') as HTMLDivElement;
       this._renderer.addClass(element, 'ngx-fg-tooltip');
-      element.innerText = data.label;
+      element.textContent = data.label;
       this._renderer.appendChild(this._elementRef.nativeElement, element);
 
       const { clientWidth, clientHeight } = element;


### PR DESCRIPTION
Based on the advice of http://www.kellegous.com/j/2013/02/27/innertext-vs-textcontent/, `textContent` should be preferred over `innerHTML`. This also fixes a lint error that arises when syncing into g3

cc @hawkgs 